### PR TITLE
Excercise 5 did not have platform configured in .sln files

### DIFF
--- a/Exercise 5/Completed/EmailClient.sln
+++ b/Exercise 5/Completed/EmailClient.sln
@@ -5,8 +5,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EmailClient", "EmailClient.
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Release = Release
-		Debug = Debug
+		Release|Any CPU = Release|Any CPU
+		Debug|Any CPU = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{70002894-B103-4E08-AB13-AC7B0EFADD2D}.Debug.ActiveCfg = Debug|Any CPU

--- a/Exercise 5/Start/EmailClient.sln
+++ b/Exercise 5/Start/EmailClient.sln
@@ -5,8 +5,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EmailClient", "EmailClient.
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Release = Release
-		Debug = Debug
+		Release|Any CPU = Release|Any CPU
+		Debug|Any CPU = Debug|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{70002894-B103-4E08-AB13-AC7B0EFADD2D}.Debug.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
This causes nuget restore to crash, and also crashed VS 15.4 preview opening the sln file. This commit has the minimal changes to make it work and not crash anything, although VS suggests further changes when it loads the project, which I will not include for this purpose.
